### PR TITLE
View directory not found

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -64,9 +64,4 @@ return [
             'ZfSimpleMigrations\Controller\Migrate' => 'ZfSimpleMigrations\\Controller\\MigrateControllerFactory'
         ],
     ],
-    'view_manager' => [
-        'template_path_stack' => [
-            __DIR__ . '/../view',
-        ],
-    ],
 ];


### PR DESCRIPTION
If you use ZfcTwig and ZfSimpleMigration together you have an error 

> Fatal error: Uncaught exception 'Twig_Error_Loader' with message 'vendor/vgarvardt/zf-simple-migrations/config/../view/" directory does not exist ("./vendor/vgarvardt/zf-simple-migrations/config/../view/").' in /vendor/zendframework/zendframework/library/Zend/ServiceManager/ServiceManager.php on line 930

because module hasnt view directory, but define this