### PR TITLE
$e->getCode() can not be called

### DIFF
--- a/src/ZfSimpleMigrations/Library/Migration.php
+++ b/src/ZfSimpleMigrations/Library/Migration.php
@@ -314,7 +314,7 @@ class Migration implements ServiceLocatorAwareInterface
         } catch (\Exception $e) {
             $this->connection->rollback();
             $msg = sprintf('%s; File: %s; Line #%d', $e->getMessage(), $e->getFile(), $e->getLine());
-            throw new MigrationException($msg, $e->getCode(), $e);
+            throw new MigrationException($msg);
         }
     }
 


### PR DESCRIPTION
In some PHP versions it is not possible to call $e->getCode().
Especially with db errors it makes more sense to give back the message only.